### PR TITLE
Fix Neo4j connectivity from Google Cloud Run with VPC egress

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
-        # Note: Python 3.13 excluded due to dependency compatibility issues
+        python-version: ["3.11", "3.12", "3.13"]
+        # Python 3.13 re-enabled with updated dependencies (July 2025)
     
     steps:
     - uses: actions/checkout@v4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,12 @@
 # Development and Testing Dependencies
 # Install with: pip install -r requirements-dev.txt
 # (After installing core requirements.txt)
+# Python 3.13 Compatible (Updated July 2025)
 
 # Testing Framework
 pytest==8.4.0
 pytest-asyncio==0.21.1
-httpx<0.28  # Pin for FastAPI TestClient compatibility
+httpx==0.28.1  # Updated - compatible with FastAPI TestClient
 
 # Development Tools (optional)
 # black                    # Code formatting

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,37 +1,35 @@
 # Core Runtime Dependencies for Arrgh! Newsletter Processing System
 # Install with: pip install -r requirements.txt
 
-# Web Framework
-fastapi==0.104.1
-uvicorn[standard]==0.24.0
-requests==2.31.0
-httpx<0.28  # Pin for FastAPI TestClient compatibility
+# Web Framework - Updated to latest stable versions with Python 3.13 support
+fastapi==0.115.5
+uvicorn[standard]==0.32.1
+requests==2.32.3
+httpx==0.28.1  # Updated from constraint, compatible with new FastAPI
 
-# LLM and AI Framework
-openai==1.35.3
-langchain==0.2.5
-langchain-community==0.2.5
-langchain-openai==0.1.8
-langgraph==0.1.4
+# LLM and AI Framework - Minimal updates, focused compatibility
+openai==1.54.0  # Latest stable with Python 3.13 wheels
+langchain-openai==0.2.6  # Only package we actually use from LangChain
+langchain-core==0.3.15  # Required dependency for langchain-openai
 
-# Graph Database
-neo4j==5.15.0
+# Graph Database - Latest stable
+neo4j==5.26.0
 
-# Data Processing
-beautifulsoup4==4.12.2
-lxml==4.9.4
-html2text==2020.1.16
+# Data Processing - Updated to versions with Python 3.13 wheels
+beautifulsoup4==4.12.3
+lxml==5.3.0  # Major update for Python 3.13 wheels
+html2text==2024.2.26
 
-# Data Validation and Configuration
-pydantic==2.5.0
-pydantic-settings==2.1.0
-python-dotenv==1.0.0
+# Data Validation and Configuration - Critical for Python 3.13
+pydantic==2.9.2  # Latest with Python 3.13 wheels
+pydantic-settings==2.6.1
+python-dotenv==1.0.1
 
 # Date/Time Utilities
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 
-# Utilities
-typing-extensions==4.8.0
+# Utilities - Updated for Python 3.13 compatibility
+typing-extensions==4.12.2
 
 # Monitoring and Logging
 structlog==23.2.0

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -48,7 +48,7 @@ gcloud run deploy $SERVICE_NAME \
   --set-env-vars ENABLE_ASYNC_PROCESSING=true \
   --set-env-vars ENABLE_ENTITY_CACHING=true \
   --set-env-vars ENABLE_DEBUG_MODE=false \
-  --set-env-vars CORS_ORIGINS=https://arrgh.paulbonneville.com \
+  --set-env-vars CORS_ORIGINS="[\"https://arrgh.paulbonneville.com\"]" \
   --set-secrets OPENAI_API_KEY=newsletter-openai-api-key:latest \
   --set-secrets NEO4J_PASSWORD=newsletter-neo4j-password:latest \
   --set-secrets NEO4J_URI=newsletter-neo4j-uri:latest \
@@ -58,6 +58,9 @@ gcloud run deploy $SERVICE_NAME \
   --concurrency 80 \
   --max-instances 10 \
   --timeout 900 \
+  --vpc-egress all \
+  --network default \
+  --subnet default \
   --no-allow-unauthenticated
 
 echo "✅ Deployment complete!"

--- a/src/config.py
+++ b/src/config.py
@@ -133,8 +133,9 @@ class Settings(BaseSettings):
     @field_validator('neo4j_uri')
     def validate_neo4j_uri(cls, v):
         """Basic validation of Neo4j URI format."""
-        if not (v.startswith('bolt://') or v.startswith('neo4j://') or v.startswith('neo4j+s://')):
-            raise ValueError('Neo4j URI must start with bolt://, neo4j://, or neo4j+s://')
+        valid_prefixes = ['bolt://', 'bolt+s://', 'neo4j://', 'neo4j+s://']
+        if not any(v.startswith(prefix) for prefix in valid_prefixes):
+            raise ValueError(f'Neo4j URI must start with one of: {", ".join(valid_prefixes)}')
         return v
     
     model_config = {

--- a/src/graph/neo4j_client.py
+++ b/src/graph/neo4j_client.py
@@ -20,8 +20,10 @@ class Neo4jClient:
         """Establish connection to Neo4j."""
         try:
             # Log connection details (without password)
+            parsed_uri = urlparse(self.config.NEO4J_URI)
+            sanitized_uri = f"{parsed_uri.hostname}:{parsed_uri.port}"
             logger.info("Attempting Neo4j connection", 
-                       uri=self.config.NEO4J_URI,
+                       uri=sanitized_uri,
                        user=self.config.NEO4J_USER,
                        password_length=len(self.config.NEO4J_PASSWORD) if self.config.NEO4J_PASSWORD else 0)
             

--- a/src/graph/neo4j_client.py
+++ b/src/graph/neo4j_client.py
@@ -19,6 +19,12 @@ class Neo4jClient:
     def connect(self) -> bool:
         """Establish connection to Neo4j."""
         try:
+            # Log connection details (without password)
+            logger.info("Attempting Neo4j connection", 
+                       uri=self.config.NEO4J_URI,
+                       user=self.config.NEO4J_USER,
+                       password_length=len(self.config.NEO4J_PASSWORD) if self.config.NEO4J_PASSWORD else 0)
+            
             self.driver = GraphDatabase.driver(
                 self.config.NEO4J_URI, 
                 auth=(self.config.NEO4J_USER, self.config.NEO4J_PASSWORD)


### PR DESCRIPTION
## Summary
Resolves Neo4j connectivity issues from Google Cloud Run by implementing Direct VPC egress configuration and updating dependency compatibility.

## Key Changes
- **VPC Egress Configuration**: Added `--vpc-egress all --network default --subnet default` to Cloud Run deployment to enable external service connectivity
- **Neo4j Protocol Support**: Updated URI validation to support both `bolt+s://` and `neo4j+s://` protocols for Neo4j Aura compatibility
- **Debug Logging**: Added connection debugging to Neo4j client for troubleshooting
- **Python 3.13 Support**: Updated all dependencies to Python 3.13 compatible versions
- **CI/CD Improvements**: Re-enabled Python 3.13 testing and fixed deployment configuration

## Technical Details
The root cause was Google Cloud Run's default egress limitations preventing connections to external services like Neo4j Aura. Direct VPC egress resolves this by routing traffic through Google Cloud's network infrastructure, enabling proper connectivity to managed database services.

## Test Plan
- [x] Neo4j connection successfully establishes from Cloud Run
- [x] VPC egress configuration deploys without errors
- [x] Python 3.13 compatibility verified
- [x] CI/CD pipeline passes with updated dependencies
- [x] Configuration validation accepts all Neo4j URI protocols

🤖 Generated with [Claude Code](https://claude.ai/code)