### PR TITLE
Replace genai references with arrgh-fastapi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,8 @@ uvicorn src.main:app --reload --port 8000
 ./scripts/dev-local.sh
 
 # Or manually:
-docker build -t genai .
-docker run -p 8080:8080 genai
+docker build -t arrgh-fastapi .
+docker run -p 8080:8080 arrgh-fastapi
 ```
 
 ### Neo4j Database (for notebook development)
@@ -149,10 +149,10 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
 
 ### Google Cloud Configuration
 - **Project**: paulbonneville-com
-- **Service**: genai
+- **Service**: arrgh-fastapi
 - **Region**: us-central1
 - **Service Account**: genai-app@paulbonneville-com.iam.gserviceaccount.com
-- **Service URL**: https://genai-860937201650.us-central1.run.app
+- **Service URL**: https://arrgh-newsletter-860937201650.us-central1.run.app
 
 ## Important Notes
 

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ git push origin main
 
 # Manual deployment
 ./scripts/dev-local.sh              # Test locally first
-gcloud run deploy genai \
-  --image gcr.io/paulbonneville-com/genai \
+gcloud run deploy arrgh-fastapi \
+  --image gcr.io/paulbonneville-com/arrgh-fastapi \
   --platform managed \
   --region us-central1 \
   --no-allow-unauthenticated
@@ -242,4 +242,4 @@ python -m pytest tests/ -v                 # Tests
 
 ---
 
-**Live Service**: https://genai-860937201650.us-central1.run.app (requires authentication)
+**Live Service**: https://arrgh-newsletter-860937201650.us-central1.run.app (requires authentication)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
       - 'run'
       - 'services'
       - 'update'
-      - 'genai'
+      - 'arrgh-fastapi'
       - '--platform=managed'
       - '--image=us-central1-docker.pkg.dev/paulbonneville-com/cloud-run-source-deploy/arrgh-fastapi/arrgh-fastapi:$COMMIT_SHA'
       - '--labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID'

--- a/docs/ENVIRONMENT-SETUP.md
+++ b/docs/ENVIRONMENT-SETUP.md
@@ -79,7 +79,7 @@ export ENVIRONMENT=production
 python -c "from src.config import get_settings, print_configuration_summary; print_configuration_summary(get_settings())"
 
 # Deploy
-gcloud run deploy genai --image gcr.io/paulbonneville-com/genai
+gcloud run deploy arrgh-fastapi --image gcr.io/paulbonneville-com/arrgh-fastapi
 ```
 
 ### Run Jupyter Notebook

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-# Stop and remove any running container named 'genai'
-if [ $(docker ps -q -f name=genai) ]; then
-  echo "Stopping running 'genai' container..."
-  docker stop genai
-  docker rm genai
+# Stop and remove any running container named 'arrgh-fastapi'
+if [ $(docker ps -q -f name=arrgh-fastapi) ]; then
+  echo "Stopping running 'arrgh-fastapi' container..."
+  docker stop arrgh-fastapi
+  docker rm arrgh-fastapi
 fi
 
 # Build the Docker image
-echo "Building Docker image 'genai'..."
-docker build -t genai .
+echo "Building Docker image 'arrgh-fastapi'..."
+docker build -t arrgh-fastapi .
 
 # Run the Docker container
-echo "Running Docker container 'genai' on port 8080..."
-docker run -d --name genai -p 8080:8080 genai
+echo "Running Docker container 'arrgh-fastapi' on port 8080..."
+docker run -d --name arrgh-fastapi -p 8080:8080 arrgh-fastapi
 
 # Wait for the app to start
 echo "Waiting for the app to start..."


### PR DESCRIPTION
## Summary
- Replace all references to "genai" with "arrgh-fastapi" for consistent service naming
- Update Cloud Build configuration to deploy to arrgh-fastapi service
- Update development scripts and documentation

## Changes
- **cloudbuild.yaml**: Deploy to `arrgh-fastapi` service instead of `genai`
- **scripts/dev-local.sh**: Use `arrgh-fastapi` container name
- **CLAUDE.md**: Update service references and Docker commands
- **README.md**: Update deployment commands
- **docs/ENVIRONMENT-SETUP.md**: Update deployment examples

## Notes
- Kept existing service account references (genai-app@...) to avoid breaking existing infrastructure
- This creates a new arrgh-fastapi service that will receive future deployments
- The urlparse import fix from the previous PR is already merged

## Test plan
- [x] All tests pass locally
- [ ] Deploy creates new arrgh-fastapi service
- [ ] Verify newsletter processing works in new service

🤖 Generated with [Claude Code](https://claude.ai/code)