### PR TITLE
Update remaining arrgh-newsletter references to arrgh-fastapi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,8 +110,8 @@ python -m pytest tests/test_simple.py::TestHTMLProcessor -v
 ./scripts/deploy-production.sh
 
 # Manual deployment (if needed)
-gcloud run deploy arrgh-newsletter \
-  --image gcr.io/paulbonneville-com/arrgh-newsletter \
+gcloud run deploy arrgh-fastapi \
+  --image gcr.io/paulbonneville-com/arrgh-fastapi \
   --platform managed \
   --region us-central1 \
   --set-secrets OPENAI_API_KEY=newsletter-openai-api-key:latest \
@@ -121,7 +121,7 @@ gcloud run deploy arrgh-newsletter \
   --no-allow-unauthenticated
 
 # View deployment logs
-gcloud logs tail --follow --service arrgh-newsletter --region us-central1
+gcloud logs tail --follow --service arrgh-fastapi --region us-central1
 ```
 
 ## Architecture
@@ -152,7 +152,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
 - **Service**: arrgh-fastapi
 - **Region**: us-central1
 - **Service Account**: 860937201650-compute@developer.gserviceaccount.com (default)
-- **Service URL**: https://arrgh-newsletter-860937201650.us-central1.run.app
+- **Service URL**: https://arrgh-fastapi-860937201650.us-central1.run.app
 
 ## Important Notes
 

--- a/README.md
+++ b/README.md
@@ -242,4 +242,4 @@ python -m pytest tests/ -v                 # Tests
 
 ---
 
-**Live Service**: https://arrgh-newsletter-860937201650.us-central1.run.app (requires authentication)
+**Live Service**: https://arrgh-fastapi-860937201650.us-central1.run.app (requires authentication)

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -10,7 +10,7 @@ echo "🚀 Deploying Newsletter Processing API to Google Cloud Run..."
 # Set project and region
 PROJECT_ID="paulbonneville-com"
 REGION="us-central1"
-SERVICE_NAME="arrgh-newsletter"
+SERVICE_NAME="arrgh-fastapi"
 
 # Ensure we're using the correct project
 gcloud config set project $PROJECT_ID


### PR DESCRIPTION
Complete service naming consistency by updating the last remaining references to arrgh-newsletter.

## Changes
- **README.md**: Update live service URL to arrgh-fastapi service
- **CLAUDE.md**: Update deployment commands and service URL references  
- **scripts/deploy-production.sh**: Update SERVICE_NAME to deploy to arrgh-fastapi

## Summary
This completes the transition from the old inconsistent naming (genai/arrgh-newsletter) to the consistent arrgh-fastapi service name throughout the entire project.

🤖 Generated with [Claude Code](https://claude.ai/code)