### PR TITLE
Fix Neo4j connection logging to include protocol scheme

### DIFF
--- a/src/graph/neo4j_client.py
+++ b/src/graph/neo4j_client.py
@@ -22,7 +22,7 @@ class Neo4jClient:
         try:
             # Log connection details (without password)
             parsed_uri = urlparse(self.config.NEO4J_URI)
-            sanitized_uri = f"{parsed_uri.hostname}:{parsed_uri.port}"
+            sanitized_uri = f"{parsed_uri.scheme}://{parsed_uri.hostname}:{parsed_uri.port}"
             logger.info("Attempting Neo4j connection", 
                        uri=sanitized_uri,
                        user=self.config.NEO4J_USER,


### PR DESCRIPTION
## Summary
- Fix Neo4j connection logging to include the protocol scheme (bolt+s://) 
- Previously only logged hostname:port, missing critical connection details
- Essential for debugging Neo4j Aura connections in production

## Test plan
- [x] Verify logging shows complete URI with protocol scheme
- [x] Confirm production secrets are properly configured
- [ ] Test connection logging in Cloud Run deployment

🤖 Generated with [Claude Code](https://claude.ai/code)