### PR TITLE
Update Neo4j Python driver to version 5.28.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ httpx==0.28.1  # Updated from constraint, compatible with new FastAPI
 openai==1.54.0  # Latest stable with Python 3.13.5 wheels
 
 # Graph Database - Latest stable
-neo4j==5.26.0
+neo4j==5.28.1
 
 # Data Processing - Updated to versions with Python 3.13.5 wheels
 beautifulsoup4==4.12.3


### PR DESCRIPTION
## Summary
• Updated Neo4j Python driver from 5.26.0 to 5.28.1
• Fixes Neo4j connectivity issues reported
• Includes 2 months of bug fixes and improvements from Neo4j team

## Test plan
- [x] All existing tests pass with new driver version
- [x] Neo4j connectivity confirmed working with updated driver
- [x] No breaking changes in driver API usage

🤖 Generated with [Claude Code](https://claude.ai/code)