### PR TITLE
Fix OpenAI client initialization error in production

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ requests==2.32.3
 httpx==0.28.1  # Updated from constraint, compatible with new FastAPI
 
 # LLM and AI Framework - Only what we actually use
-openai==1.54.0  # Latest stable with Python 3.13.5 wheels
+openai==1.93.2  # Latest stable, fixes 'proxies' parameter error
 
 # Graph Database - Latest stable
 neo4j==5.26.0


### PR DESCRIPTION
## Summary
- Updated OpenAI SDK from 1.54.0 to 1.93.2 to fix production initialization error
- Resolves the `proxies` parameter error that was preventing entity extraction

## Problem
The production deployment was failing to initialize the OpenAI client with error:
```
Failed to initialize OpenAI client: Client.__init__() got an unexpected keyword argument 'proxies'
```

This prevented entity extraction from working, even though Neo4j writes were successful.

## Solution
Updated to the latest OpenAI SDK version (1.93.2) which doesn't have this issue. This fix was previously done in commit 671b850 but didn't make it to the main branch.

## Testing
✅ Deployed to production successfully
✅ OpenAI client now initializes without errors
✅ Newsletter processing works (3 newsletters processed)
✅ Neo4j connection and writes confirmed working

## Note
Entity extraction is returning 0 entities, but this is a separate issue (likely related to confidence thresholds or prompt tuning) and not related to this initialization fix.

🤖 Generated with [Claude Code](https://claude.ai/code)