### PR TITLE
Update Docker healthcheck interval to 15 minutes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ USER appuser
 EXPOSE 8080
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=15m --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import requests; requests.get('http://localhost:8080/health')" || exit 1
 
 # Run the app with Uvicorn


### PR DESCRIPTION
## Summary
- Increased Docker healthcheck interval from 30s to 15m to reduce resource usage and costs for Cloud Run deployments

## Test plan
- [ ] Verify Docker build succeeds with new healthcheck configuration
- [ ] Deploy to Cloud Run and confirm reduced healthcheck frequency
- [ ] Monitor application health and performance

🤖 Generated with [Claude Code](https://claude.ai/code)